### PR TITLE
Google geocoder service

### DIFF
--- a/app/services/google_service.rb
+++ b/app/services/google_service.rb
@@ -3,4 +3,19 @@ class GoogleService
     @filter = filter
   end
 
+  def geocode_search
+    json = get_json("/maps/api/geocode/json?key=#{ENV["google_geocode_api_key"]}&address=#{@filter}")
+    json[:results].first[:geometry][:location]
+  end
+
+  private
+
+  def conn
+    Faraday.new(url: "https://maps.googleapis.com")
+  end
+
+  def get_json(url)
+    JSON.parse(conn.get(url).body, symbolize_names: true)
+  end
+
 end

--- a/spec/services/google_service_spec.rb
+++ b/spec/services/google_service_spec.rb
@@ -3,18 +3,15 @@ require 'rails_helper'
 describe GoogleService do
   subject { GoogleService.new("80215") }
 
-  it 'exists' do
-    expect(subject).to be_a(GoogleService)
-  end
-
-  context 'geocoding data' do
+  context '#geocode_search' do
     context 'with valid zip code' do
       it "returns geocoded latitude and longitude" do
-      results = subject.geocoded_data
 
-      expect(results.first).to have_key[:lat]
-      expect(results.first).to have_key[:lng]
+        results = subject.geocode_search
+
+        expect(results).to have_key(:lat)
+        expect(results).to have_key(:lng)
+      end
     end
   end
-
 end


### PR DESCRIPTION
adds google geocoder api access through service model

method #geocode_search returns hash of lat/lng keys with values from google geocoder api

closes #9