### PR TITLE
Get coats fix

### DIFF
--- a/app/controllers/api/v1/coats_controller.rb
+++ b/app/controllers/api/v1/coats_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::CoatsController < ApplicationController
   def index
-    if current_user
+    if request_params[:api_key] && confirmed_user_by_key
       render json: CoatSerializer.new(user_coats)
     else
       render json: {}, status: 401
@@ -25,7 +25,7 @@ class Api::V1::CoatsController < ApplicationController
   private
 
   def user_coats
-    Coat.where(user_id: current_user[:id])
+    Coat.where(user_id: confirmed_user_by_key[:id])
   end
 
   def confirmed_user_by_key

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,2 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
-
-  helper_method :current_user
-
-  def current_user
-    @current_user ||= User.find(session[:user_id]) if session[:user_id]
-  end
 end

--- a/spec/requests/api/v1/coats/coats_request_spec.rb
+++ b/spec/requests/api/v1/coats/coats_request_spec.rb
@@ -6,15 +6,13 @@ describe 'Coats API' do
       it 'creates a new coat' do
         user = create(:user)
 
-        headers = { "Content-Type" => "application/json",
-                    "Accept" => "application/json"}
-        json_payload = { title: "winter",
-                        precip_condition: "snow",
-                        high_temp: "50",
-                        low_temp: "-10",
-                        api_key: "#{user.api_key}"}.to_json
+        payload = { title: "winter",
+                    precip_condition: "snow",
+                    high_temp: "50",
+                    low_temp: "-10",
+                    api_key: user.api_key}
 
-        post "/api/v1/coats", params: json_payload, headers: headers
+        post "/api/v1/coats", params: payload
 
         expect(response.status).to eq(201)
         expect(user.coats.length).to eq(1)
@@ -25,14 +23,12 @@ describe 'Coats API' do
       it 'returns a 401 error' do
         user = create(:user)
 
-        headers = { "Content-Type" => "application/json",
-                    "Accept" => "application/json"}
-        json_payload = { title: "winter",
+        payload = { title: "winter",
                         precip_condition: "snow",
                         high_temp: "50",
-                        low_temp: "-10"}.to_json
+                        low_temp: "-10"}
 
-        post "/api/v1/coats", params: json_payload, headers: headers
+        post "/api/v1/coats", params: payload
 
         expect(response.status).to eq(401)
         expect(user.coats.length).to eq(0)
@@ -43,15 +39,13 @@ describe 'Coats API' do
       it 'returns a 401 error' do
         user = create(:user)
 
-        headers = { "Content-Type" => "application/json",
-                    "Accept" => "application/json"}
-        json_payload = { title: "winter",
+        payload = { title: "winter",
                         precip_condition: "snow",
                         high_temp: "50",
                         low_temp: "-10",
-                        api_key: "wrong_api_key"}.to_json
+                        api_key: "wrong_api_key"}
 
-        post "/api/v1/coats", params: json_payload, headers: headers
+        post "/api/v1/coats", params: payload
 
         expect(response.status).to eq(401)
         expect(user.coats.length).to eq(0)
@@ -68,9 +62,9 @@ describe 'Coats API' do
         user_2 = create(:user)
         user_2_coat = create(:coat)
 
-        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
+        payload = { api_key: user_1.api_key }
 
-        get "/api/v1/coats"
+        get "/api/v1/coats", params: payload
 
         expect(response.status).to eq(200)
 
@@ -85,11 +79,24 @@ describe 'Coats API' do
       end
     end
 
-    context 'with user not logged in' do
+    context 'with no api key' do
       it 'returns a 401 error' do
         user_1 = create(:user)
+        user_1_coat = create(:coat, user_id: user_1.id)
 
-        get "/api/v1/coats"
+        get "/api/v1/coats", headers: headers
+
+        expect(response.status).to eq(401)
+      end
+    end
+
+    context 'with incorrect api key' do
+      it 'returns 401 error' do
+        user_1 = create(:user)
+
+        payload = { api_key: "wrong api key" }
+
+        get "/api/v1/coats", params: payload, headers: headers
 
         expect(response.status).to eq(401)
       end


### PR DESCRIPTION
remove current_helper method from application controller
remove json headers from spec - these do not appear necessary at this time, will reevaluate if there is an issue later
it was added previously to try to scope controller AR query to a trusted object, however this is now accomplished through finding the user by API key, as is correct for an API